### PR TITLE
Fix metadata encoding of too-big notification messages

### DIFF
--- a/spns/notifiers/util.py
+++ b/spns/notifiers/util.py
@@ -48,7 +48,8 @@ def encrypt_notify_payload(data: dict, max_msg_size: int = 2500):
             metadata["B"] = True
             body = None
 
-    payload = bt_serialize([json.dumps(metadata), body] if body else [metadata])
+    metadata_json = json.dumps(metadata)
+    payload = bt_serialize([metadata_json, body] if body else [metadata_json])
     over = len(payload) % 256
     if over:
         payload += b"\0" * (256 - over)


### PR DESCRIPTION
If a message body is too large, we omit it from the notification, but we were not encoding that as json and so the metadata would end up as a (bt-encoded) dict within the notification rather than a bt-encoded string containing the json.

This fixes it to use the same json encoding as we use when sending a message that doesn't exceed the limit.